### PR TITLE
Make sure to close network socket after it's open

### DIFF
--- a/JJG/Ping.php
+++ b/JJG/Ping.php
@@ -271,12 +271,11 @@ class Ping {
     // irrelevant errors and deal with the results instead.
     $fp = @fsockopen($this->host, $this->port, $errno, $errstr, $this->timeout);
     if (!$fp) {
-      $latency = false;
+      return false;
     }
-    else {
-      $latency = microtime(true) - $start;
-      $latency = round($latency * 1000, 4);
-    }
+    $latency = microtime(true) - $start;
+    $latency = round($latency * 1000, 4);
+    fclose($fp);
     return $latency;
   }
 


### PR DESCRIPTION
Problem: the 'fsockopen' method opens a socket connection, but never closes it. When pinging multiple hosts multiple times, this leaves the host with many zombie TIME_WAIT connections.
This PR adds a line ```fclose($fp);``` to close the connection after opening it.